### PR TITLE
Restore Seance texture

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -63,7 +63,7 @@ AltTexture{
     key = 'joker',
     set = 'Joker',
     path = 'Jokers-TSpectrals.png',
-    keys = {'j_banner'},
+    keys = {'j_banner','j_seance'},
     original_sheet = true
 }
 


### PR DESCRIPTION
Restores the Seance texture from the original mod. (It was already present in the sprite sheet, it just went unused.)